### PR TITLE
Update Route53 record to also include the environment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- #4: Update Route53 record to also include the environment name
+
 ## [1.0.0] - 2018-06-21
 https://github.com/philips-software/terraform-aws-rds/tags/1.0.0
 

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_db_instance" "db" {
 
 resource "aws_route53_record" "db" {
   zone_id = "${var.vpc_private_dns_zone_id}"
-  name    = "db.${var.name}"
+  name    = "db.${var.environment}-${var.name}"
   type    = "CNAME"
   ttl     = "300"
 


### PR DESCRIPTION
There is a need to have separate Route53 records if you run development / test / production.